### PR TITLE
Add auto refresh and alert utilities

### DIFF
--- a/actions/alert.js
+++ b/actions/alert.js
@@ -1,0 +1,37 @@
+"use server";
+import { db } from "@/lib/prisma";
+
+export const createAlert = async ({ visitorId, type, message }) => {
+  try {
+    const alert = await db.alert.create({
+      data: { visitorId, type, message },
+    });
+    return alert;
+  } catch (error) {
+    console.error("Error creating alert:", error);
+    throw new Error("Failed to create alert.");
+  }
+};
+
+export const getClientAlerts = async (clientId) => {
+  try {
+    const alerts = await db.alert.findMany({
+      where: {
+        visitor: { clientId },
+      },
+      orderBy: { triggeredAt: "desc" },
+      include: { visitor: { select: { name: true } } },
+      take: 20,
+    });
+    return alerts.map((a) => ({
+      id: a.id,
+      type: a.type,
+      message: a.message,
+      triggeredAt: a.triggeredAt,
+      visitorName: a.visitor.name,
+    }));
+  } catch (error) {
+    console.error("Error fetching alerts:", error);
+    throw new Error("Failed to fetch alerts.");
+  }
+};

--- a/actions/visitor.js
+++ b/actions/visitor.js
@@ -1,5 +1,6 @@
 "use server";
 import { db } from "@/lib/prisma";
+import { createAlert } from "./alert";
 
 export const visitRequestByGuard = async (visitData) => {
   try {
@@ -11,6 +12,11 @@ export const visitRequestByGuard = async (visitData) => {
         requestedByGuard: true,
         status: "PENDING",
       },
+    });
+    await createAlert({
+      visitorId: visitor.id,
+      type: "ENTRY",
+      message: `${visitor.name} visit requested`,
     });
     return visitor;
   } catch (error) {

--- a/app/client-view/dashboard/_components/Alerts.jsx
+++ b/app/client-view/dashboard/_components/Alerts.jsx
@@ -1,40 +1,80 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { Info, CheckCircle, LogOut, AlertTriangle } from "lucide-react";
+import { getClientAlerts } from "@/actions/alert";
+import { toast } from "sonner";
 
 const alertVariants = {
-  checkIn: {
+  ENTRY: {
     icon: <CheckCircle className="h-5 w-5 text-green-500" />,
     title: "Visitor Checked In",
     color: "border-green-500 bg-green-50",
   },
-  checkOut: {
+  EXIT: {
     icon: <LogOut className="h-5 w-5 text-blue-500" />,
     title: "Visitor Checked Out",
     color: "border-blue-500 bg-blue-50",
   },
-  newVisitor: {
-    icon: <Info className="h-5 w-5 text-yellow-500" />,
-    title: "New Visitor Added",
-    color: "border-yellow-500 bg-yellow-50",
-  },
-  timeout: {
+  TIMEOUT: {
     icon: <AlertTriangle className="h-5 w-5 text-red-600" />,
     title: "Visitor Overstayed",
     color: "border-red-600 bg-red-50",
   },
+  DEFAULT: {
+    icon: <Info className="h-5 w-5 text-yellow-500" />,
+    title: "Alert",
+    color: "border-yellow-500 bg-yellow-50",
+  },
 };
 
-export default function Alerts({ type = "newVisitor", message }) {
-    
-  const alert = alertVariants[type] || alertVariants.newVisitor;
+export default function Alerts() {
+  const [alerts, setAlerts] = useState([]);
+
+  const fetchAlerts = async () => {
+    try {
+      const client = JSON.parse(localStorage.getItem("clientInfo"));
+      const data = await getClientAlerts(client?.clientId);
+      setAlerts(data);
+    } catch (err) {
+      toast.error("Failed to fetch alerts.");
+    }
+  };
+
+  useEffect(() => {
+    fetchAlerts();
+    const interval = setInterval(fetchAlerts, 10000);
+    return () => clearInterval(interval);
+  }, []);
 
   return (
-    <Alert className={`flex items-start gap-3 ${alert.color}`}>
-      <div className="mt-1">{alert.icon}</div>
-      <div>
-        <AlertTitle>{alert.title}</AlertTitle>
-        <AlertDescription>{message}</AlertDescription>
-      </div>
-    </Alert>
+    <Card>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-lg font-semibold">Alerts</h2>
+          <Button size="sm" onClick={fetchAlerts}>Refresh</Button>
+        </div>
+        {alerts.length > 0 ? (
+          <div className="space-y-3 max-h-96 overflow-y-auto pr-2">
+            {alerts.map((alert) => {
+              const variant = alertVariants[alert.type] || alertVariants.DEFAULT;
+              return (
+                <Alert key={alert.id} className={`flex items-start gap-3 ${variant.color}`}> 
+                  <div className="mt-1">{variant.icon}</div>
+                  <div>
+                    <AlertTitle>{variant.title}</AlertTitle>
+                    <AlertDescription>{alert.message}</AlertDescription>
+                  </div>
+                </Alert>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">No alerts available.</p>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/app/client-view/dashboard/_components/IncomingRequests.jsx
+++ b/app/client-view/dashboard/_components/IncomingRequests.jsx
@@ -22,7 +22,8 @@ export default function IncomingRequests() {
 
   const fetchRequests = async () => {
     try {
-      const data = await getPendingVisitorRequests();
+      const client = JSON.parse(localStorage.getItem("clientInfo"));
+      const data = await getPendingVisitorRequests(client?.clientId);
       setRequests(data);
     } catch (err) {
       toast.error("Failed to fetch visitor requests.");
@@ -31,6 +32,8 @@ export default function IncomingRequests() {
 
   useEffect(() => {
     fetchRequests();
+    const interval = setInterval(fetchRequests, 10000);
+    return () => clearInterval(interval);
   }, []);
 
   const handleChange = (field, value) => {
@@ -77,7 +80,10 @@ export default function IncomingRequests() {
   return (
     <Card>
       <CardContent className="p-4">
-        <h2 className="text-lg font-semibold mb-4">Visit Requests</h2>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold">Visit Requests</h2>
+          <Button size="sm" onClick={fetchRequests}>Refresh</Button>
+        </div>
         {requests.length > 0 ? (
           <div className="flex flex-col space-y-3 max-h-96 overflow-y-auto pr-2">
             {requests.map((item, idx) => (

--- a/app/client-view/dashboard/_components/VisitorRecords.jsx
+++ b/app/client-view/dashboard/_components/VisitorRecords.jsx
@@ -1,23 +1,26 @@
 import { useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { getAllVisitorRecords } from "@/actions/client";
 import { toast } from "sonner";
 
 export default function VisitorRecords() {
   const [records, setRecords] = useState([]);
+  const fetchRecords = async () => {
+    try {
+      const client = JSON.parse(localStorage.getItem("clientInfo"));
+      const data = await getAllVisitorRecords(client?.clientId);
+      setRecords(data);
+    } catch (err) {
+      toast.error("Failed to load visitor records.");
+    }
+  };
 
   useEffect(() => {
-    const fetchRecords = async () => {
-      try {
-        const data = await getAllVisitorRecords();
-        setRecords(data);
-      } catch (err) {
-        toast.error("Failed to load visitor records.");
-      }
-    };
-
     fetchRecords();
+    const interval = setInterval(fetchRecords, 10000);
+    return () => clearInterval(interval);
   }, []);
 
   const getBadgeVariant = (status) => {
@@ -36,7 +39,10 @@ export default function VisitorRecords() {
   return (
     <Card className="overflow-scroll">
       <CardContent className="p-4">
-        <h3 className="text-lg font-semibold mb-4">Visitor Records</h3>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold">Visitor Records</h3>
+          <Button size="sm" onClick={fetchRecords}>Refresh</Button>
+        </div>
         {records.length > 0 ? (
           <div className="overflow-x-auto">
             <table className="w-full text-sm text-left border-collapse">

--- a/app/client-view/dashboard/page.jsx
+++ b/app/client-view/dashboard/page.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import IncomingRequests from "./_components/IncomingRequests";
 import AddVisitor from "./_components/AddVisitor";
@@ -8,7 +8,12 @@ import Alerts from "./_components/Alerts";
 
 export default function ClientDashboard() {
   const [activeSection, setActiveSection] = useState("requests");
-  const clientData = JSON.parse(localStorage.getItem("clientInfo"));
+  const [clientData, setClientData] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("clientInfo");
+    if (stored) setClientData(JSON.parse(stored));
+  }, []);
 
   const dummyRequests = ["Visitor A - 10:00 AM", "Visitor B - 11:30 AM", "Visitor F - 12:00 PM"];
   const dummyApprovals = ["Visitor C", "Visitor G"];
@@ -29,6 +34,8 @@ export default function ClientDashboard() {
         return null;
     }
   };
+
+  if (!clientData) return null;
 
   return (
     <div className="min-h-screen p-6 bg-gray-100">


### PR DESCRIPTION
## Summary
- auto-refresh visitor request and records every 10s
- add refresh button to lists
- create alert utilities and show alerts list
- ensure dashboard reads client info in `useEffect`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686d32226480832f9e13a34d16781222