### PR TITLE
Adjust visitor approval workflow

### DIFF
--- a/actions/client.js
+++ b/actions/client.js
@@ -92,25 +92,30 @@ export const approveVisitorRequest = async ({
 }) => {
   try {
     const now = new Date();
-    const existing = await db.visitor.findUnique({
-      where: { id: visitorId },
-      select: { requestedByGuard: true, requestedByEndUser: true, scheduledExit: true },
-    });
+  const existing = await db.visitor.findUnique({
+    where: { id: visitorId },
+    select: {
+      requestedByGuard: true,
+      requestedByEndUser: true,
+      scheduledExit: true,
+      name: true,
+    },
+  });
 
     if (!existing) throw new Error("Visitor not found");
 
     if (existing.requestedByEndUser) {
-      await db.visitor.update({
-        where: { id: visitorId },
-        data: { status: "SCHEDULED", approvedByClient: byClient },
-      });
-      await createAlert({
-        visitorId,
-        type: "SCHEDULED",
-        message: `Visit scheduled`,
-      });
-      return { success: true };
-    }
+    await db.visitor.update({
+      where: { id: visitorId },
+      data: { status: "SCHEDULED", approvedByClient: byClient },
+    });
+    await createAlert({
+      visitorId,
+      type: "SCHEDULED",
+      message: `Visit request for ${existing.name} approved`,
+    });
+    return { success: true };
+  }
 
     let scheduledExit;
     if (durationHours !== undefined || durationMinutes !== undefined) {
@@ -136,7 +141,9 @@ export const approveVisitorRequest = async ({
     await createAlert({
       visitorId,
       type: existing.requestedByGuard ? "CHECKED_IN" : "SCHEDULED",
-      message: existing.requestedByGuard ? `Visitor checked in` : `Visit approved`,
+      message: existing.requestedByGuard
+        ? `${existing.name} checked in`
+        : `${existing.name} visit approved`,
     });
 
     return { success: true };

--- a/actions/client.js
+++ b/actions/client.js
@@ -125,17 +125,18 @@ export const approveVisitorRequest = async ({
     await db.visitor.update({
       where: { id: visitorId },
       data: {
-        status: "APPROVED",
+        status: existing.requestedByGuard ? "CHECKED_IN" : "APPROVED",
         scheduledEntry: now,
         scheduledExit,
         approvedByClient: byClient,
+        checkInTime: existing.requestedByGuard ? now : undefined,
       },
     });
 
     await createAlert({
       visitorId,
-      type: "SCHEDULED",
-      message: `Visit approved`,
+      type: existing.requestedByGuard ? "CHECKED_IN" : "SCHEDULED",
+      message: existing.requestedByGuard ? `Visitor checked in` : `Visit approved`,
     });
 
     return { success: true };

--- a/actions/enduser.js
+++ b/actions/enduser.js
@@ -151,11 +151,17 @@ export const deleteEndUser = async (id) => {
   }
 };
 
-export const updateEndUserCredentials = async ({ id, email, password }) => {
+export const updateEndUserCredentials = async ({
+  id,
+  email,
+  password,
+  approvalType,
+}) => {
   try {
     const data = {};
     if (email) data.email = email;
     if (password) data.password = await bcrypt.hash(password, 10);
+    if (approvalType) data.approvalType = approvalType;
     await db.endUser.update({ where: { id }, data });
     return { success: true };
   } catch (err) {

--- a/actions/enduser.js
+++ b/actions/enduser.js
@@ -1,6 +1,7 @@
 "use server";
 import { db } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
+import { createAlert } from "./alert";
 
 export const createEndUser = async (data) => {
   try {
@@ -64,6 +65,11 @@ export const addVisitorByEndUser = async ({
         requestedByGuard: false,
         status: "PENDING",
       },
+    });
+    await createAlert({
+      visitorId: visitor.id,
+      type: "REQUESTED",
+      message: `Visit request for ${visitor.name} sent to client`,
     });
     return visitor;
   } catch (err) {

--- a/actions/visitor.js
+++ b/actions/visitor.js
@@ -73,6 +73,11 @@ export const getScheduledVisitors = async () => {
 export const validateVisitor = async ({ visitorId, otp, vehicleImage }) => {
   if (otp !== "1234") throw new Error("Invalid OTP");
   try {
+    const existing = await db.visitor.findUnique({ where: { id: visitorId }, select: { status: true } });
+    if (!existing) throw new Error("Visitor not found");
+    if (existing.status === "CHECKED_IN") {
+      throw new Error("Visitor already checked in with the qr/otp");
+    }
     const updateData = { status: "CHECKED_IN", checkInTime: new Date() };
     if (vehicleImage) updateData.vehicleImage = vehicleImage;
     const visitor = await db.visitor.update({
@@ -134,7 +139,7 @@ export const checkInVisitorByQr = async (visitorId, vehicleImage) => {
     }
 
     if (existing.status === "CHECKED_IN") {
-      throw new Error("Already checked in with this QR.");
+      throw new Error("Visitor already checked in with the qr/otp");
     }
 
     const updateData = { status: "CHECKED_IN", checkInTime: new Date() };

--- a/app/client-view/dashboard/_components/Alerts.jsx
+++ b/app/client-view/dashboard/_components/Alerts.jsx
@@ -100,7 +100,12 @@ export default function Alerts({ onNew }) {
                   <div className="mt-1">{variant.icon}</div>
                   <div className="flex-1">
                     <AlertTitle>{variant.title}</AlertTitle>
-                    <AlertDescription>{alert.message}</AlertDescription>
+                    <AlertDescription>
+                      {alert.message}
+                      <span className="block text-xs mt-1 text-muted-foreground">
+                        {new Date(alert.triggeredAt).toLocaleString()}
+                      </span>
+                    </AlertDescription>
                   </div>
                   <Button size="icon" variant="ghost" onClick={() => handleDelete(alert.id)}>
                     <X className="h-4 w-4" />

--- a/app/client-view/dashboard/_components/EndUserList.jsx
+++ b/app/client-view/dashboard/_components/EndUserList.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
 import {
   getEndUsersByClient,
   deleteEndUser,
@@ -12,11 +13,12 @@ import { toast } from "sonner";
 
 const fmt = (v) =>
   v.replace(/_/g, " ").toLowerCase().replace(/^\w/, (c) => c.toUpperCase());
+const approvalTypes = ["CLIENT_ONLY", "END_USER_ONLY", "BOTH"];
 
 export default function EndUserList({ clientId, onDeps }) {
   const [users, setUsers] = useState([]);
   const [editing, setEditing] = useState(null);
-  const [form, setForm] = useState({ email: "", password: "" });
+  const [form, setForm] = useState({ email: "", password: "", approvalType: "CLIENT_ONLY" });
 
   const fetchUsers = async () => {
     try {
@@ -47,7 +49,7 @@ export default function EndUserList({ clientId, onDeps }) {
       await updateEndUserCredentials({ id, ...form });
       toast.success("Updated");
       setEditing(null);
-      setForm({ email: "", password: "" });
+      setForm({ email: "", password: "", approvalType: "CLIENT_ONLY" });
       fetchUsers();
     } catch {
       toast.error("Failed to update");
@@ -65,6 +67,7 @@ export default function EndUserList({ clientId, onDeps }) {
                 <th className="p-2 border-b font-medium">Department</th>
                 <th className="p-2 border-b font-medium">Email</th>
                 <th className="p-2 border-b font-medium">Post</th>
+                <th className="p-2 border-b font-medium">Approval</th>
                 <th className="p-2 border-b font-medium">Actions</th>
               </tr>
             </thead>
@@ -85,6 +88,22 @@ export default function EndUserList({ clientId, onDeps }) {
                     )}
                   </td>
                   <td className="p-2">{u.post}</td>
+                  <td className="p-2">
+                    {editing === u.id ? (
+                      <Select onValueChange={(v)=>setForm(p=>({...p,approvalType:v}))} defaultValue={form.approvalType}>
+                        <SelectTrigger className="w-36">
+                          <SelectValue placeholder="Select" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {approvalTypes.map((t) => (
+                            <SelectItem key={t} value={t}>{fmt(t)}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      fmt(u.approvalType)
+                    )}
+                  </td>
                   <td className="p-2 space-x-2">
                     {editing === u.id ? (
                       <>
@@ -98,13 +117,26 @@ export default function EndUserList({ clientId, onDeps }) {
                         <Button size="sm" onClick={() => handleUpdate(u.id)}>
                           Save
                         </Button>
-                        <Button size="sm" variant="ghost" onClick={() => setEditing(null)}>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setEditing(null);
+                            setForm({ email: "", password: "", approvalType: "CLIENT_ONLY" });
+                          }}
+                        >
                           Cancel
                         </Button>
                       </>
                     ) : (
                       <>
-                        <Button size="sm" onClick={() => {setEditing(u.id); setForm({ email: u.email, password: "" });}}>
+                        <Button
+                          size="sm"
+                          onClick={() => {
+                            setEditing(u.id);
+                            setForm({ email: u.email, password: "", approvalType: u.approvalType });
+                          }}
+                        >
                           Update
                         </Button>
                         <Button size="sm" variant="destructive" onClick={() => handleDelete(u.id)}>

--- a/app/client-view/dashboard/_components/IncomingRequests.jsx
+++ b/app/client-view/dashboard/_components/IncomingRequests.jsx
@@ -149,7 +149,9 @@ export default function IncomingRequests({ onNew }) {
                     )}
                   </p>
                   {item.requestedByGuard ? (
-                    <p className="text-xs text-muted-foreground">Requested by guard</p>
+                    <p className="text-xs text-muted-foreground">
+                      Requested by guard for {fmt(item.department)}
+                    </p>
                   ) : item.requestedByEndUser ? (
                     <p className="text-xs text-muted-foreground">Added by {fmt(item.department)}</p>
                   ) : null}

--- a/app/end-user-view/dashboard/_components/Alerts.jsx
+++ b/app/end-user-view/dashboard/_components/Alerts.jsx
@@ -85,7 +85,12 @@ export default function AlertsEndUser({ user }) {
                   <div className="mt-1">{variant.icon}</div>
                   <div className="flex-1">
                     <AlertTitle>{variant.title}</AlertTitle>
-                    <AlertDescription>{alert.message}</AlertDescription>
+                    <AlertDescription>
+                      {alert.message}
+                      <span className="block text-xs mt-1 text-muted-foreground">
+                        {new Date(alert.triggeredAt).toLocaleString()}
+                      </span>
+                    </AlertDescription>
                   </div>
                 </AlertCmp>
               );


### PR DESCRIPTION
## Summary
- extend end-user update action to support approval type
- display and edit approval type in end-user list
- show department name on guard raised requests
- auto check in visitors approved from guard requests
- warn when attempting to validate already checked-in visitors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68726bcd862c832f848375982352a90c