### PR TITLE
Implement session-based auth

### DIFF
--- a/actions/client.js
+++ b/actions/client.js
@@ -3,6 +3,7 @@
 import { db } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import { createAlert } from "./alert";
+import { setSession } from "@/lib/session";
 
 export const createClient = async (clientData) => {
     try {
@@ -37,7 +38,14 @@ export const signInClient = async ({ email, password }) => {
         if (!isValid) {
             throw new Error("Incorrect email/password.");
         }
-        return client;
+        setSession({ id: client.id, role: "client" });
+        return {
+            id: client.id,
+            name: client.name,
+            email: client.email,
+            phone: client.phone,
+            department: client.department,
+        };
     } catch (err) {
         console.error("Sign-in error:", err.message);
         throw new Error(err.message || "Something went wrong during sign-in.");

--- a/actions/enduser.js
+++ b/actions/enduser.js
@@ -2,6 +2,7 @@
 import { db } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import { createAlert } from "./alert";
+import { setSession } from "@/lib/session";
 
 export const createEndUser = async (data) => {
   try {
@@ -30,7 +31,17 @@ export const signInEndUser = async ({ email, password }) => {
     if (!user) throw new Error("No account found with this email.");
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) throw new Error("Incorrect email/password.");
-    return user;
+    setSession({ id: user.id, role: "enduser" });
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      department: user.department,
+      post: user.post,
+      approvalType: user.approvalType,
+      canAddVisitor: user.canAddVisitor,
+      clientId: user.clientId,
+    };
   } catch (err) {
     console.error("Sign-in error:", err);
     throw new Error(err.message || "Sign-in failed");

--- a/actions/session.js
+++ b/actions/session.js
@@ -1,0 +1,39 @@
+"use server";
+import { db } from "@/lib/prisma";
+import { getSessionData, clearSession } from "@/lib/session";
+
+export const getCurrentClient = async () => {
+  const session = getSessionData();
+  if (!session || session.role !== "client") return null;
+  const c = await db.client.findUnique({ where: { id: session.id } });
+  if (!c) return null;
+  return {
+    clientId: c.id,
+    name: c.name,
+    email: c.email,
+    phone: c.phone,
+    department: c.department,
+  };
+};
+
+export const getCurrentEndUser = async () => {
+  const session = getSessionData();
+  if (!session || session.role !== "enduser") return null;
+  const u = await db.endUser.findUnique({ where: { id: session.id } });
+  if (!u) return null;
+  return {
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    department: u.department,
+    post: u.post,
+    approvalType: u.approvalType,
+    canAddVisitor: u.canAddVisitor,
+    clientId: u.clientId,
+  };
+};
+
+export const signOut = async () => {
+  clearSession();
+  return { success: true };
+};

--- a/app/client-view/dashboard/_components/AddEndUserForm.jsx
+++ b/app/client-view/dashboard/_components/AddEndUserForm.jsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
 import { createEndUser } from "@/actions/enduser";
+import { getCurrentClient } from "@/actions/session";
 import { toast } from "sonner";
 
 const departments = ["FINANCE", "ADMIN", "HR", "IT", "OPERATIONS"];
@@ -26,7 +27,7 @@ export default function AddEndUserForm({ used = [] }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const client = JSON.parse(localStorage.getItem("clientInfo"));
+    const client = await getCurrentClient();
     if (!client) return;
     if (!form.name || !form.email || !form.password || !form.department)
       return toast.error("Please fill all fields");

--- a/app/client-view/dashboard/_components/AddVisitor.jsx
+++ b/app/client-view/dashboard/_components/AddVisitor.jsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Calendar } from "@/components/ui/calendar";
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
 import { addVisitorByClient } from "@/actions/client";
+import { getCurrentClient } from "@/actions/session";
 import { toast } from "sonner";
 
 const departments = ["FINANCE", "ADMIN", "HR", "IT", "OPERATIONS"];
@@ -46,7 +47,7 @@ export default function AddVisitor() {
 
     setLoading(true);
     try {
-      const client = JSON.parse(localStorage.getItem("clientInfo"));
+      const client = await getCurrentClient();
       const scheduledEntry = new Date(`${visitDate.toDateString()} ${entryTime}`);
       const scheduledExit = new Date(scheduledEntry.getTime() +
         parseInt(durationHours) * 60 * 60 * 1000 +

--- a/app/client-view/dashboard/_components/AddVisitor.jsx
+++ b/app/client-view/dashboard/_components/AddVisitor.jsx
@@ -122,7 +122,7 @@ export default function AddVisitor() {
             <Label className="block text-sm font-medium mb-1">Entry Time</Label>
             <Input type="time" name="entryTime" value={formData.entryTime} onChange={handleChange} required />
           </div>
-          <div className="flex space-x-2">
+          <div className="flex flex-col sm:flex-row gap-2">
             <div className="flex-1">
               <Label className="block text-sm font-medium mb-1">Visit Duration (Hours)</Label>
               <Input type="number" name="durationHours" value={formData.durationHours} onChange={handleChange} min="0" required />

--- a/app/client-view/dashboard/_components/Alerts.jsx
+++ b/app/client-view/dashboard/_components/Alerts.jsx
@@ -5,6 +5,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Info, CheckCircle, LogOut, AlertTriangle, RefreshCw, X } from "lucide-react";
 import { getClientAlerts, deleteAlert } from "@/actions/alert";
+import { getCurrentClient } from "@/actions/session";
 import { toast } from "sonner";
 
 const alertVariants = {
@@ -53,7 +54,7 @@ export default function Alerts({ onNew }) {
   const fetchAlerts = async () => {
     setLoading(true);
     try {
-      const client = JSON.parse(localStorage.getItem("clientInfo"));
+      const client = await getCurrentClient();
       const data = await getClientAlerts(client?.clientId);
       setAlerts(data);
       if (onNew && data.length > prevCount.current) {

--- a/app/client-view/dashboard/_components/EndUserSection.jsx
+++ b/app/client-view/dashboard/_components/EndUserSection.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import { getCurrentClient } from "@/actions/session";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import EndUserList from "./EndUserList";
 import AddEndUserForm from "./AddEndUserForm";
@@ -9,8 +10,11 @@ export default function EndUserSection() {
   const [used, setUsed] = useState([]);
 
   useEffect(() => {
-    const stored = localStorage.getItem("clientInfo");
-    if (stored) setClientId(JSON.parse(stored).clientId);
+    const load = async () => {
+      const client = await getCurrentClient();
+      if (client) setClientId(client.clientId);
+    };
+    load();
   }, []);
 
   return (

--- a/app/client-view/dashboard/_components/IncomingRequests.jsx
+++ b/app/client-view/dashboard/_components/IncomingRequests.jsx
@@ -13,6 +13,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { getPendingVisitorRequests,approveVisitorRequest,denyVisitorRequest } from "@/actions/client";
+import { getCurrentClient } from "@/actions/session";
 import { toast } from "sonner";
 
 const fmt = (v) =>
@@ -30,7 +31,7 @@ export default function IncomingRequests({ onNew }) {
   const fetchRequests = async () => {
     setLoading(true);
     try {
-      const client = JSON.parse(localStorage.getItem("clientInfo"));
+      const client = await getCurrentClient();
       const data = await getPendingVisitorRequests(client?.clientId);
       setRequests(data);
       if (onNew && data.length > prevCount.current) {

--- a/app/client-view/dashboard/_components/VisitorRecords.jsx
+++ b/app/client-view/dashboard/_components/VisitorRecords.jsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import QRCode from "react-qr-code";
 import { getAllVisitorRecords } from "@/actions/client";
+import { getCurrentClient } from "@/actions/session";
 import { toast } from "sonner";
 
 const fmt = (v) => v.replace(/_/g, " ").toLowerCase().replace(/^\w/, (c) => c.toUpperCase());
@@ -22,7 +23,7 @@ export default function VisitorRecords() {
   const fetchRecords = async () => {
     setLoading(true);
     try {
-      const client = JSON.parse(localStorage.getItem("clientInfo"));
+      const client = await getCurrentClient();
       const data = await getAllVisitorRecords(client?.clientId);
       setRecords(data);
     } catch (err) {

--- a/app/client-view/dashboard/_components/VisitorRecords.jsx
+++ b/app/client-view/dashboard/_components/VisitorRecords.jsx
@@ -63,19 +63,19 @@ export default function VisitorRecords() {
         </div>
         {records.length > 0 ? (
           <div className="overflow-x-auto">
-            <table className="w-full text-sm text-left border-collapse">
+            <table className="min-w-[800px] w-full text-xs md:text-sm text-left border-collapse">
               <thead className="bg-muted">
                 <tr>
                   <th className="p-2 border-b font-medium">Name</th>
-                  <th className="p-2 border-b font-medium">Vehicle No.</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Vehicle No.</th>
                   <th className="p-2 border-b font-medium">Department</th>
                   <th className="p-2 border-b font-medium">Date</th>
-                  <th className="p-2 border-b font-medium">Scheduled CheckIn</th>
-                  <th className="p-2 border-b font-medium">Scheduled Checkout</th>
-                  <th className="p-2 border-b font-medium">Actual CheckIn Date</th>
-                  <th className="p-2 border-b font-medium">Actual CheckIn</th>
-                  <th className="p-2 border-b font-medium">Actual CheckOut</th>
-                  <th className="p-2 border-b font-medium">Approved By</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Scheduled CheckIn</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Scheduled Checkout</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Actual CheckIn Date</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Actual CheckIn</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Actual CheckOut</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Approved By</th>
                   <th className="p-2 border-b font-medium">Status</th>
                   <th className="p-2 border-b font-medium">QR</th>
                 </tr>
@@ -83,8 +83,8 @@ export default function VisitorRecords() {
               <tbody className="divide-y">
                 {records.map((visitor) => (
                   <tr key={visitor.id}>
-                    <td className="p-2">{visitor.name}</td>
-                    <td className="p-2">
+                    <td className="p-2 whitespace-nowrap">{visitor.name}</td>
+                    <td className="p-2 hidden md:table-cell">
                       {visitor.vehicleImage ? (
                         <Dialog>
                           <DialogTrigger asChild>
@@ -101,14 +101,14 @@ export default function VisitorRecords() {
                         "N/A"
                       )}
                     </td>
-                    <td className="p-2">{fmt(visitor.department)}</td>
-                    <td className="p-2">{visitor.date}</td>
-                    <td className="p-2">{visitor.scheduledCheckIn}</td>
-                    <td className="p-2">{visitor.scheduledCheckOut}</td>
-                    <td className="p-2">{visitor.checkInDate}</td>
-                    <td className="p-2">{visitor.checkInTime}</td>
-                    <td className="p-2">{visitor.checkOutTime}</td>
-                    <td className="p-2">{visitor.approvedBy ? fmt(visitor.approvedBy) : "-"}</td>
+                    <td className="p-2 whitespace-nowrap">{fmt(visitor.department)}</td>
+                    <td className="p-2 whitespace-nowrap">{visitor.date}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.scheduledCheckIn}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.scheduledCheckOut}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.checkInDate}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.checkInTime}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.checkOutTime}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.approvedBy ? fmt(visitor.approvedBy) : "-"}</td>
                     <td className="p-2">
                       <Badge variant={getBadgeVariant(visitor.status)} className="text-xs">
                         {fmt(visitor.status)}

--- a/app/client-view/dashboard/page.jsx
+++ b/app/client-view/dashboard/page.jsx
@@ -61,7 +61,7 @@ export default function ClientDashboard() {
         </div>
       </header>
 
-      <nav className="flex space-x-4 border-b pb-2 mb-4">
+      <nav className="flex flex-wrap gap-2 border-b pb-2 mb-4">
         <Button
           variant={activeSection === "requests" ? "default" : "outline"}
           className={newRequests && activeSection !== "requests" ? "border-yellow-500" : ""}

--- a/app/client-view/dashboard/page.jsx
+++ b/app/client-view/dashboard/page.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import { getCurrentClient } from "@/actions/session";
 import { Button } from "@/components/ui/button";
 import IncomingRequests from "./_components/IncomingRequests";
 import AddVisitor from "./_components/AddVisitor";
@@ -14,8 +15,11 @@ export default function ClientDashboard() {
   const [newRequests, setNewRequests] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem("clientInfo");
-    if (stored) setClientData(JSON.parse(stored));
+    const load = async () => {
+      const data = await getCurrentClient();
+      if (data) setClientData(data);
+    };
+    load();
   }, []);
 
   useEffect(() => {

--- a/app/client-view/sign-in/page.jsx
+++ b/app/client-view/sign-in/page.jsx
@@ -30,16 +30,8 @@ export default function ClientSignIn() {
         }
         setLoading(true);
         try {
-            const res = await signInClient({ email, password });
+            await signInClient({ email, password });
             toast.success("Login successful!");
-            localStorage.setItem("clientInfo", JSON.stringify({
-                name: res.name,
-                email: res.email,
-                phone: res.phone,
-                clientId:res.id,
-                department: res.department,
-            }));
-
             router.push("/client-view/dashboard");
         } catch (err) {
             setError(err.message || "An unexpected error occurred.");

--- a/app/end-user-view/dashboard/_components/AddVisitor.jsx
+++ b/app/end-user-view/dashboard/_components/AddVisitor.jsx
@@ -77,7 +77,7 @@ export default function AddVisitorEndUser({ user }) {
             <Label className="block text-sm font-medium mb-1">Entry Time</Label>
             <Input type="time" name="entryTime" value={formData.entryTime} onChange={handleChange} required />
           </div>
-          <div className="flex space-x-2">
+          <div className="flex flex-col sm:flex-row gap-2">
             <div className="flex-1">
               <Label className="block text-sm font-medium mb-1">Duration (Hours)</Label>
               <Input type="number" name="durationHours" value={formData.durationHours} onChange={handleChange} min="0" required />

--- a/app/end-user-view/dashboard/_components/VisitorRecords.jsx
+++ b/app/end-user-view/dashboard/_components/VisitorRecords.jsx
@@ -57,17 +57,17 @@ export default function VisitorRecordsEndUser({ user }) {
         </div>
         {records.length > 0 ? (
           <div className="overflow-x-auto">
-            <table className="w-full text-sm text-left border-collapse">
+            <table className="min-w-[700px] w-full text-xs md:text-sm text-left border-collapse">
               <thead className="bg-muted">
                 <tr>
                   <th className="p-2 border-b font-medium">Name</th>
                   <th className="p-2 border-b font-medium">Date</th>
                   <th className="p-2 border-b font-medium">Scheduled CheckIn</th>
                   <th className="p-2 border-b font-medium">Scheduled Checkout</th>
-                  <th className="p-2 border-b font-medium">Actual CheckIn Date</th>
-                  <th className="p-2 border-b font-medium">Actual CheckIn</th>
-                  <th className="p-2 border-b font-medium">Actual CheckOut</th>
-                  <th className="p-2 border-b font-medium">Approved By</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Actual CheckIn Date</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Actual CheckIn</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Actual CheckOut</th>
+                  <th className="p-2 border-b font-medium hidden md:table-cell">Approved By</th>
                   <th className="p-2 border-b font-medium">Status</th>
                   <th className="p-2 border-b font-medium">QR</th>
                 </tr>
@@ -75,14 +75,14 @@ export default function VisitorRecordsEndUser({ user }) {
               <tbody className="divide-y">
                 {records.map((visitor) => (
                   <tr key={visitor.id}>
-                    <td className="p-2">{visitor.name}</td>
-                    <td className="p-2">{visitor.date}</td>
-                    <td className="p-2">{visitor.scheduledCheckIn}</td>
-                    <td className="p-2">{visitor.scheduledCheckOut}</td>
-                    <td className="p-2">{visitor.checkInDate}</td>
-                    <td className="p-2">{visitor.checkInTime}</td>
-                    <td className="p-2">{visitor.checkOutTime}</td>
-                    <td className="p-2">{visitor.approvedBy ? fmt(visitor.approvedBy) : "-"}</td>
+                    <td className="p-2 whitespace-nowrap">{visitor.name}</td>
+                    <td className="p-2 whitespace-nowrap">{visitor.date}</td>
+                    <td className="p-2 whitespace-nowrap">{visitor.scheduledCheckIn}</td>
+                    <td className="p-2 whitespace-nowrap">{visitor.scheduledCheckOut}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.checkInDate}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.checkInTime}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.checkOutTime}</td>
+                    <td className="p-2 hidden md:table-cell whitespace-nowrap">{visitor.approvedBy ? fmt(visitor.approvedBy) : "-"}</td>
                     <td className="p-2">
                       <Badge variant={getBadgeVariant(visitor.status)} className="text-xs">
                         {fmt(visitor.status)}

--- a/app/end-user-view/dashboard/page.jsx
+++ b/app/end-user-view/dashboard/page.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { getCurrentEndUser } from "@/actions/session";
 import { Button } from "@/components/ui/button";
 import IncomingRequests from "./_components/IncomingRequests";
 import AddVisitor from "./_components/AddVisitor";
@@ -10,8 +11,11 @@ export default function EndUserDashboard(){
   const [user,setUser]=useState(null);
   const [activeSection,setActiveSection]=useState("requests");
   useEffect(()=>{
-    const stored = localStorage.getItem("endUserInfo");
-    if(stored) setUser(JSON.parse(stored));
+    const load = async () => {
+      const data = await getCurrentEndUser();
+      if(data) setUser(data);
+    };
+    load();
   },[]);
 
   const renderSection = () => {

--- a/app/end-user-view/dashboard/page.jsx
+++ b/app/end-user-view/dashboard/page.jsx
@@ -44,7 +44,7 @@ export default function EndUserDashboard(){
         <p className="text-gray-600">Post: {user.post}</p>
       </header>
 
-      <nav className="flex space-x-4 border-b pb-2 mb-4">
+      <nav className="flex flex-wrap gap-2 border-b pb-2 mb-4">
         <Button variant={activeSection === "requests" ? "default" : "outline"} onClick={()=>setActiveSection("requests")}>Incoming Requests</Button>
         {user.canAddVisitor && (
           <Button variant={activeSection === "add" ? "default" : "outline"} onClick={()=>setActiveSection("add")}>Add a Visitor</Button>

--- a/app/end-user-view/sign-in/page.jsx
+++ b/app/end-user-view/sign-in/page.jsx
@@ -22,18 +22,8 @@ export default function EndUserSignIn(){
     }
     setLoading(true);
     try{
-      const res = await signInEndUser(form);
+      await signInEndUser(form);
       toast.success("Login successful!");
-      localStorage.setItem("endUserInfo", JSON.stringify({
-        id: res.id,
-        name: res.name,
-        email: res.email,
-        department: res.department,
-        post: res.post,
-        approvalType: res.approvalType,
-        canAddVisitor: res.canAddVisitor,
-        clientId: res.clientId,
-      }));
       router.push("/end-user-view/dashboard");
     }catch(err){
       setError(err.message || "An error occurred");

--- a/app/guard-view/page.jsx
+++ b/app/guard-view/page.jsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import {
+import { 
     visitRequestByGuard,
     getVisitorLogsForGuard,
     getScheduledVisitors,
@@ -16,6 +16,7 @@ import {
     checkoutVisitor,
     checkInVisitorByQr,
   } from "@/actions/visitor";
+import { getCurrentClient } from "@/actions/session";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
 import dynamic from "next/dynamic";
@@ -109,8 +110,8 @@ export default function GuardView() {
 
 
   const handleRequestSubmit = async () => {
-    const client = JSON.parse(localStorage.getItem("clientInfo"));
-    request.clientId = client.clientId;
+    const client = await getCurrentClient();
+    request.clientId = client?.clientId;
     setRequestLoading(true);
     try {
       await visitRequestByGuard(request);

--- a/app/guard-view/page.jsx
+++ b/app/guard-view/page.jsx
@@ -408,8 +408,8 @@ export default function GuardView() {
                 {logs.length === 0 ? (
                   <p className="text-sm text-muted-foreground">No visitor requests found.</p>
                 ) : (
-                  <div className="overflow-auto">
-                    <table className="w-full text-sm text-left border-collapse">
+                  <div className="overflow-x-auto">
+                    <table className="min-w-[500px] w-full text-xs md:text-sm text-left border-collapse">
                       <thead className="bg-muted">
                         <tr>
                           <th className="p-2 border-b">Name</th>

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,0 +1,27 @@
+import { cookies } from 'next/headers';
+import jwt from 'jsonwebtoken';
+
+const COOKIE_NAME = 'session';
+
+export function setSession(data) {
+  const token = jwt.sign(data, process.env.JWT_SECRET || 'secret');
+  cookies().set(COOKIE_NAME, token, {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'lax',
+  });
+}
+
+export function getSessionData() {
+  const token = cookies().get(COOKIE_NAME)?.value;
+  if (!token) return null;
+  try {
+    return jwt.verify(token, process.env.JWT_SECRET || 'secret');
+  } catch {
+    return null;
+  }
+}
+
+export function clearSession() {
+  cookies().delete(COOKIE_NAME);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.525.0",
         "next": "15.3.5",
         "next-themes": "^0.4.6",
@@ -3016,6 +3017,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -3408,6 +3415,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -5027,6 +5043,28 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -5041,6 +5079,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -5342,11 +5401,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -5480,7 +5581,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6282,6 +6382,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6327,7 +6447,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.525.0",
     "next": "15.3.5",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## Summary
- add JWT-based session helpers
- add server actions to read session data
- set session cookie on client and end-user sign in
- fetch user data from sessions across the dashboard
- remove all localStorage usage
- add `jsonwebtoken` dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687279553a10832f8a7670efd5e7606b