### PR TITLE
Fix missing Prisma query engine in prod

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,7 @@
 generator client {
   provider = "prisma-client-js"
   output   = "../lib/generated/prisma"
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- include `rhel-openssl-3.0.x` in Prisma binary targets

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687284eeb00c832fa493ef0c8c4e6bb5