### PR TITLE
Add binary engine config to Prisma client generator

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,6 +8,7 @@ generator client {
   provider = "prisma-client-js"
   output   = "../lib/generated/prisma"
   binaryTargets = ["native", "rhel-openssl-3.0.x"]
+  engineType = "binary"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- configure the Prisma client generator to use the binary engine

## Testing
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_b_68728a80719c832fadf8f1b8908a2112