### PR TITLE
Add postbuild Prisma copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
 
+## Building for production
+
+Run the build command:
+```bash
+npm run build
+```
+
+This runs a "postbuild" script that copies the Prisma client from `node_modules/.prisma` and `lib/generated/prisma` into `.next/standalone` so the runtime can find the `query-engine-*` binaries.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "npx prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "postbuild": "node scripts/copy-prisma.js"
   },
   "dependencies": {
     "@prisma/client": "^6.11.1",

--- a/scripts/copy-prisma.js
+++ b/scripts/copy-prisma.js
@@ -1,0 +1,14 @@
+const { cpSync, existsSync, mkdirSync } = require('fs');
+const { join, dirname } = require('path');
+
+const destRoot = join('.next', 'standalone');
+const paths = ['node_modules/.prisma', 'lib/generated/prisma'];
+
+for (const p of paths) {
+  if (existsSync(p)) {
+    const dest = join(destRoot, p);
+    mkdirSync(dirname(dest), { recursive: true });
+    cpSync(p, dest, { recursive: true });
+  }
+}
+console.log('Copied Prisma directories to standalone folder');


### PR DESCRIPTION
## Summary
- copy generated Prisma client into the standalone build output
- run the copy step from a new `postbuild` script
- document the new build step in the README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68729002cd38832f81ef3f562b803fd1