### PR TITLE
Update Prisma schema binary targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 Copy `.env.example` to `.env` and fill in the required values before running the development server.
 
+Install dependencies with `npm install`. This step generates the Prisma Client automatically. If you later modify `prisma/schema.prisma`, run `npx prisma generate` to update the client.
+
 First, run the development server:
 
 ```bash

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@
 generator client {
   provider = "prisma-client-js"
   output   = "../lib/generated/prisma"
-  binaryTargets = ["native", "rhel-openssl-3.0.x"]
+  binaryTargets = ["native", "debian-openssl-3.0.x", "rhel-openssl-1.0.x"]
   engineType = "binary"
 }
 


### PR DESCRIPTION
## Summary
- expand `generator.client` binary targets for Debian and RHEL
- document Prisma client generation steps

## Testing
- `npm run lint`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_b_68729002a80c832fa2a52980a70961f8