### PR TITLE
Fix cookie access in session utils

### DIFF
--- a/actions/client.js
+++ b/actions/client.js
@@ -38,7 +38,7 @@ export const signInClient = async ({ email, password }) => {
         if (!isValid) {
             throw new Error("Incorrect email/password.");
         }
-        setSession({ id: client.id, role: "client" });
+        await setSession({ id: client.id, role: "client" });
         return {
             id: client.id,
             name: client.name,

--- a/actions/enduser.js
+++ b/actions/enduser.js
@@ -31,7 +31,7 @@ export const signInEndUser = async ({ email, password }) => {
     if (!user) throw new Error("No account found with this email.");
     const valid = await bcrypt.compare(password, user.password);
     if (!valid) throw new Error("Incorrect email/password.");
-    setSession({ id: user.id, role: "enduser" });
+    await setSession({ id: user.id, role: "enduser" });
     return {
       id: user.id,
       name: user.name,

--- a/actions/session.js
+++ b/actions/session.js
@@ -3,7 +3,7 @@ import { db } from "@/lib/prisma";
 import { getSessionData, clearSession } from "@/lib/session";
 
 export const getCurrentClient = async () => {
-  const session = getSessionData();
+  const session = await getSessionData();
   if (!session || session.role !== "client") return null;
   const c = await db.client.findUnique({ where: { id: session.id } });
   if (!c) return null;
@@ -17,7 +17,7 @@ export const getCurrentClient = async () => {
 };
 
 export const getCurrentEndUser = async () => {
-  const session = getSessionData();
+  const session = await getSessionData();
   if (!session || session.role !== "enduser") return null;
   const u = await db.endUser.findUnique({ where: { id: session.id } });
   if (!u) return null;
@@ -34,6 +34,6 @@ export const getCurrentEndUser = async () => {
 };
 
 export const signOut = async () => {
-  clearSession();
+  await clearSession();
   return { success: true };
 };

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,27 +1,30 @@
-import { cookies } from 'next/headers';
-import jwt from 'jsonwebtoken';
+import { cookies } from "next/headers";
+import jwt from "jsonwebtoken";
 
-const COOKIE_NAME = 'session';
+const COOKIE_NAME = "session";
 
-export function setSession(data) {
-  const token = jwt.sign(data, process.env.JWT_SECRET || 'secret');
-  cookies().set(COOKIE_NAME, token, {
+export async function setSession(data) {
+  const token = jwt.sign(data, process.env.JWT_SECRET || "secret");
+  const store = await cookies();
+  store.set(COOKIE_NAME, token, {
     httpOnly: true,
-    path: '/',
-    sameSite: 'lax',
+    path: "/",
+    sameSite: "lax",
   });
 }
 
-export function getSessionData() {
-  const token = cookies().get(COOKIE_NAME)?.value;
+export async function getSessionData() {
+  const store = await cookies();
+  const token = store.get(COOKIE_NAME)?.value;
   if (!token) return null;
   try {
-    return jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    return jwt.verify(token, process.env.JWT_SECRET || "secret");
   } catch {
     return null;
   }
 }
 
-export function clearSession() {
-  cookies().delete(COOKIE_NAME);
+export async function clearSession() {
+  const store = await cookies();
+  store.delete(COOKIE_NAME);
 }


### PR DESCRIPTION
## Summary
- use async cookie store in session utilities
- await session methods in login and session actions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6872994d6680832fb57bff6ac350be2b