### PR TITLE
Fix guard request creation without logged client

### DIFF
--- a/actions/visitor.js
+++ b/actions/visitor.js
@@ -4,15 +4,23 @@ import { createAlert } from "./alert";
 
 export const visitRequestByGuard = async (visitData) => {
   try {
+    let clientId = visitData.clientId;
+    if (!clientId) {
+      const defaultClient = await db.client.findFirst();
+      if (!defaultClient) {
+        throw new Error("No client found");
+      }
+      clientId = defaultClient.id;
+    }
     const endUser = await db.endUser.findFirst({
-      where: { clientId: visitData.clientId, department: visitData.department },
+      where: { clientId, department: visitData.department },
     });
     const visitor = await db.visitor.create({
       data: {
         name: visitData.name,
         purpose: visitData.purpose,
         vehicleImage: visitData.vehicleImage ?? null,
-        clientId: visitData.clientId,
+        clientId,
         department: visitData.department,
         endUserName: endUser?.name ?? null,
         endUserId: endUser?.id ?? null,

--- a/app/guard-view/page.jsx
+++ b/app/guard-view/page.jsx
@@ -111,10 +111,13 @@ export default function GuardView() {
 
   const handleRequestSubmit = async () => {
     const client = await getCurrentClient();
-    request.clientId = client?.clientId;
+    const requestData = { ...request };
+    if (client?.clientId) {
+      requestData.clientId = client.clientId;
+    }
     setRequestLoading(true);
     try {
-      await visitRequestByGuard(request);
+      await visitRequestByGuard(requestData);
       toast.success("Visit request raised successfully.");
       setRequest({ name: "", purpose: "", department: "", clientId: "", vehicleImage: "" });
     } catch (err) {


### PR DESCRIPTION
## Summary
- ensure `visitRequestByGuard` assigns a client ID even when no session exists
- adjust guard view to send client ID only when available

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6872a12a792c832fa336bfe51efc5e5b