### PR TITLE
Configure Arcjet middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ DIRECT_URL=
 
 # Secret key for signing JWT tokens
 JWT_SECRET=
+
+# Arcjet site key
+ARCJET_KEY=

--- a/lib/arcjet.js
+++ b/lib/arcjet.js
@@ -1,5 +1,12 @@
-import arcjet from "@arcjet/next";
+import arcjet, { detectBot, tokenBucket } from "@arcjet/next";
 
-const aj=arcjet({
-    key:process.env.ARCJET_KEY,
-})
+// Shared Arcjet client with bot protection and rate limiting rules
+const aj = arcjet({
+  key: process.env.ARCJET_KEY,
+  rules: [
+    detectBot({ mode: "LIVE" }),
+    tokenBucket({ mode: "LIVE", interval: 60, refillRate: 10, capacity: 50 }),
+  ],
+});
+
+export default aj;

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,6 @@
+import { createMiddleware } from "@arcjet/next";
+import aj from "@/lib/arcjet";
+
+// Apply Arcjet middleware to all incoming requests
+export default createMiddleware(aj);
+


### PR DESCRIPTION
## Summary
- add ARCJET_KEY to .env.example
- configure Arcjet client with bot protection and rate limiting rules
- apply Arcjet middleware globally

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6873e8036324832f8be94c32dd547277