### PR TITLE
Fix missing Arcjet dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.11.1",
+    "@arcjet/next": "^1.0.0-beta.9",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.5",


### PR DESCRIPTION
## Summary
- include `@arcjet/next` in package.json dependencies

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6876224f9770832f9f8a60cf239167a2