### PR TITLE
Fix missing Prisma engine in serverless builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run the build command:
 npm run build
 ```
 
-This runs a "postbuild" script that copies the Prisma client from `node_modules/.prisma` and `lib/generated/prisma` into `.next/standalone` so the runtime can find the `query-engine-*` binaries.
+This runs a "postbuild" script that copies the Prisma client from `node_modules/.prisma` and `lib/generated/prisma` into both `.next/standalone` and `.next/server` so the runtime can find the `query-engine-*` binaries for Node and serverless functions.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 

--- a/scripts/copy-prisma.js
+++ b/scripts/copy-prisma.js
@@ -1,14 +1,19 @@
 const { cpSync, existsSync, mkdirSync } = require('fs');
 const { join, dirname } = require('path');
 
-const destRoot = join('.next', 'standalone');
+const destRoots = [
+  join('.next', 'standalone'),
+  join('.next', 'server'),
+];
 const paths = ['node_modules/.prisma', 'lib/generated/prisma'];
 
-for (const p of paths) {
-  if (existsSync(p)) {
-    const dest = join(destRoot, p);
-    mkdirSync(dirname(dest), { recursive: true });
-    cpSync(p, dest, { recursive: true });
+for (const destRoot of destRoots) {
+  for (const p of paths) {
+    if (existsSync(p)) {
+      const dest = join(destRoot, p);
+      mkdirSync(dirname(dest), { recursive: true });
+      cpSync(p, dest, { recursive: true });
+    }
   }
 }
-console.log('Copied Prisma directories to standalone folder');
+console.log('Copied Prisma directories to standalone and server folders');


### PR DESCRIPTION
## Summary
- copy Prisma client directories into both standalone and server folders during build
- update README to note the updated postbuild step

## Testing
- `NEXT_TELEMETRY_DISABLED=1 npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_b_68763662cd60832fa263091aae500ee1