### PR TITLE
Update guard camera orientation and persistent dashboard data

### DIFF
--- a/actions/enduser.js
+++ b/actions/enduser.js
@@ -1,7 +1,7 @@
 "use server";
 import { db } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
-import { createAlert } from "./alert";
+import { createAlert, checkOverstayedVisitors } from "./alert";
 import { setSession } from "@/lib/session";
 
 export const createEndUser = async (data) => {
@@ -128,6 +128,7 @@ export const getEndUserRecords = async (endUserId) => {
 
 export const getEndUserAlerts = async (endUserId) => {
   try {
+    await checkOverstayedVisitors();
     const alerts = await db.alert.findMany({
       where: { visitor: { endUserId } },
       orderBy: { triggeredAt: "desc" },

--- a/app/client-view/dashboard/_components/VisitorRecords.jsx
+++ b/app/client-view/dashboard/_components/VisitorRecords.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,15 +17,20 @@ import { toast } from "sonner";
 
 const fmt = (v) => v.replace(/_/g, " ").toLowerCase().replace(/^\w/, (c) => c.toUpperCase());
 
-export default function VisitorRecords() {
+export default function VisitorRecords({ onNew }) {
   const [records, setRecords] = useState([]);
   const [loading, setLoading] = useState(false);
+  const prevCount = useRef(0);
   const fetchRecords = async () => {
     setLoading(true);
     try {
       const client = await getCurrentClient();
       const data = await getAllVisitorRecords(client?.clientId);
       setRecords(data);
+      if (onNew && data.length > prevCount.current) {
+        onNew(true);
+      }
+      prevCount.current = data.length;
     } catch (err) {
       toast.error("Failed to load visitor records.");
     } finally {

--- a/app/client-view/dashboard/page.jsx
+++ b/app/client-view/dashboard/page.jsx
@@ -13,6 +13,7 @@ export default function ClientDashboard() {
   const [clientData, setClientData] = useState(null);
   const [newAlerts, setNewAlerts] = useState(false);
   const [newRequests, setNewRequests] = useState(false);
+  const [newRecords, setNewRecords] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -25,24 +26,16 @@ export default function ClientDashboard() {
   useEffect(() => {
     if (activeSection === "alerts") setNewAlerts(false);
     if (activeSection === "requests") setNewRequests(false);
+    if (activeSection === "records") setNewRecords(false);
   }, [activeSection]);
 
 
-  const renderSection = () => {
-    switch (activeSection) {
-      case "requests":
-        return <IncomingRequests onNew={setNewRequests} />;
-      case "add":
-        return <AddVisitor />;
-      case "enduser":
-        return <EndUserSection />;
-      case "records":
-        return <VisitorRecords />;
-      case "alerts":
-        return <Alerts onNew={setNewAlerts} />;
-      default:
-        return null;
-    }
+  const sections = {
+    requests: <IncomingRequests onNew={setNewRequests} />,
+    add: <AddVisitor />,
+    enduser: <EndUserSection />,
+    records: <VisitorRecords onNew={setNewRecords} />,
+    alerts: <Alerts onNew={setNewAlerts} />,
   };
 
   if (!clientData) return null;
@@ -64,25 +57,44 @@ export default function ClientDashboard() {
       <nav className="flex flex-wrap gap-2 border-b pb-2 mb-4">
         <Button
           variant={activeSection === "requests" ? "default" : "outline"}
-          className={newRequests && activeSection !== "requests" ? "border-yellow-500" : ""}
+          className="relative"
           onClick={() => setActiveSection("requests")}
         >
           Incoming Requests
+          {newRequests && activeSection !== "requests" && (
+            <span className="absolute top-0 right-0 mt-1 mr-1 w-2 h-2 bg-red-500 rounded-full" />
+          )}
         </Button>
         <Button variant={activeSection === "add" ? "default" : "outline"} onClick={() => setActiveSection("add")}>Add a Visitor</Button>
         <Button variant={activeSection === "enduser" ? "default" : "outline"} onClick={() => setActiveSection("enduser")}>End Users</Button>
-        <Button variant={activeSection === "records" ? "default" : "outline"} onClick={() => setActiveSection("records")}>Visitor Records</Button>
+        <Button
+          variant={activeSection === "records" ? "default" : "outline"}
+          className="relative"
+          onClick={() => setActiveSection("records")}
+        >
+          Visitor Records
+          {newRecords && activeSection !== "records" && (
+            <span className="absolute top-0 right-0 mt-1 mr-1 w-2 h-2 bg-red-500 rounded-full" />
+          )}
+        </Button>
         <Button
           variant={activeSection === "alerts" ? "default" : "outline"}
-          className={newAlerts && activeSection !== "alerts" ? "border-yellow-500" : ""}
+          className="relative"
           onClick={() => setActiveSection("alerts")}
         >
           Alerts
+          {newAlerts && activeSection !== "alerts" && (
+            <span className="absolute top-0 right-0 mt-1 mr-1 w-2 h-2 bg-red-500 rounded-full" />
+          )}
         </Button>
       </nav>
 
       <section className="bg-white p-4 rounded-lg shadow-md">
-        {renderSection()}
+        {Object.entries(sections).map(([key, component]) => (
+          <div key={key} className={activeSection === key ? "block" : "hidden"}>
+            {component}
+          </div>
+        ))}
       </section>
     </div>
   );

--- a/app/end-user-view/dashboard/_components/Alerts.jsx
+++ b/app/end-user-view/dashboard/_components/Alerts.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Alert as AlertCmp, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -45,15 +45,20 @@ const alertVariants = {
   },
 };
 
-export default function AlertsEndUser({ user }) {
+export default function AlertsEndUser({ user, onNew }) {
   const [alerts, setAlerts] = useState([]);
   const [loading, setLoading] = useState(false);
+  const prevCount = useRef(0);
 
   const fetchAlerts = async () => {
     setLoading(true);
     try {
       const data = await getEndUserAlerts(user.id);
       setAlerts(data);
+      if (onNew && data.length > prevCount.current) {
+        onNew(true);
+      }
+      prevCount.current = data.length;
     } catch {
       toast.error("Failed to fetch alerts.");
     } finally {

--- a/app/end-user-view/dashboard/_components/IncomingRequests.jsx
+++ b/app/end-user-view/dashboard/_components/IncomingRequests.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { RefreshCw } from "lucide-react";
@@ -15,19 +15,24 @@ import {
 import { getPendingVisitorRequests, approveVisitorRequest, denyVisitorRequest } from "@/actions/client";
 import { toast } from "sonner";
 
-export default function IncomingRequestsEndUser({ user }) {
+export default function IncomingRequestsEndUser({ user, onNew }) {
   const [requests, setRequests] = useState([]);
   const [durations, setDurations] = useState({});
   const [selectedVisitor, setSelectedVisitor] = useState(null);
   const [popupIndex, setPopupIndex] = useState(null);
   const [loading, setLoading] = useState(false);
   const [actionLoading, setActionLoading] = useState(false);
+  const prevCount = useRef(0);
 
   const fetchRequests = async () => {
     setLoading(true);
     try {
       const data = await getPendingVisitorRequests(user.clientId, user.id);
       setRequests(data);
+      if (onNew && data.length > prevCount.current) {
+        onNew(true);
+      }
+      prevCount.current = data.length;
     } catch (err) {
       toast.error("Failed to fetch visitor requests.");
     } finally {

--- a/app/end-user-view/dashboard/_components/VisitorRecords.jsx
+++ b/app/end-user-view/dashboard/_components/VisitorRecords.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -11,15 +11,20 @@ import { toast } from "sonner";
 
 const fmt = (v) => v.replace(/_/g, " ").toLowerCase().replace(/^\w/, (c) => c.toUpperCase());
 
-export default function VisitorRecordsEndUser({ user }) {
+export default function VisitorRecordsEndUser({ user, onNew }) {
   const [records, setRecords] = useState([]);
   const [loading, setLoading] = useState(false);
+  const prevCount = useRef(0);
 
   const fetchRecords = async () => {
     setLoading(true);
     try {
       const data = await getEndUserRecords(user.id);
       setRecords(data);
+      if (onNew && data.length > prevCount.current) {
+        onNew(true);
+      }
+      prevCount.current = data.length;
     } catch {
       toast.error("Failed to load visitor records.");
     } finally {

--- a/app/end-user-view/dashboard/page.jsx
+++ b/app/end-user-view/dashboard/page.jsx
@@ -10,6 +10,9 @@ import Alerts from "./_components/Alerts";
 export default function EndUserDashboard(){
   const [user,setUser]=useState(null);
   const [activeSection,setActiveSection]=useState("requests");
+  const [newRequests,setNewRequests]=useState(false);
+  const [newAlerts,setNewAlerts]=useState(false);
+  const [newRecords,setNewRecords]=useState(false);
   useEffect(()=>{
     const load = async () => {
       const data = await getCurrentEndUser();
@@ -18,20 +21,17 @@ export default function EndUserDashboard(){
     load();
   },[]);
 
-  const renderSection = () => {
-    if(!user) return null;
-    switch(activeSection){
-      case "requests":
-        return <IncomingRequests user={user} />;
-      case "add":
-        return <AddVisitor user={user} />;
-      case "records":
-        return <VisitorRecords user={user} />;
-      case "alerts":
-        return <Alerts user={user} />;
-      default:
-        return null;
-    }
+  useEffect(() => {
+    if(activeSection === "requests") setNewRequests(false);
+    if(activeSection === "alerts") setNewAlerts(false);
+    if(activeSection === "records") setNewRecords(false);
+  }, [activeSection]);
+
+  const sections = {
+    requests: <IncomingRequests user={user} onNew={setNewRequests} />,
+    add: <AddVisitor user={user} />,
+    records: <VisitorRecords user={user} onNew={setNewRecords} />,
+    alerts: <Alerts user={user} onNew={setNewAlerts} />,
   };
 
   if(!user) return null;
@@ -45,16 +45,47 @@ export default function EndUserDashboard(){
       </header>
 
       <nav className="flex flex-wrap gap-2 border-b pb-2 mb-4">
-        <Button variant={activeSection === "requests" ? "default" : "outline"} onClick={()=>setActiveSection("requests")}>Incoming Requests</Button>
+        <Button
+          variant={activeSection === "requests" ? "default" : "outline"}
+          className="relative"
+          onClick={() => setActiveSection("requests")}
+        >
+          Incoming Requests
+          {newRequests && activeSection !== "requests" && (
+            <span className="absolute top-0 right-0 mt-1 mr-1 w-2 h-2 bg-red-500 rounded-full" />
+          )}
+        </Button>
         {user.canAddVisitor && (
           <Button variant={activeSection === "add" ? "default" : "outline"} onClick={()=>setActiveSection("add")}>Add a Visitor</Button>
         )}
-        <Button variant={activeSection === "records" ? "default" : "outline"} onClick={()=>setActiveSection("records")}>Visitor Records</Button>
-        <Button variant={activeSection === "alerts" ? "default" : "outline"} onClick={()=>setActiveSection("alerts")}>Alerts</Button>
+        <Button
+          variant={activeSection === "records" ? "default" : "outline"}
+          className="relative"
+          onClick={()=>setActiveSection("records")}
+        >
+          Visitor Records
+          {newRecords && activeSection !== "records" && (
+            <span className="absolute top-0 right-0 mt-1 mr-1 w-2 h-2 bg-red-500 rounded-full" />
+          )}
+        </Button>
+        <Button
+          variant={activeSection === "alerts" ? "default" : "outline"}
+          className="relative"
+          onClick={()=>setActiveSection("alerts")}
+        >
+          Alerts
+          {newAlerts && activeSection !== "alerts" && (
+            <span className="absolute top-0 right-0 mt-1 mr-1 w-2 h-2 bg-red-500 rounded-full" />
+          )}
+        </Button>
       </nav>
 
       <section className="bg-white p-4 rounded-lg shadow-md">
-        {renderSection()}
+        {Object.entries(sections).map(([key, component]) => (
+          <div key={key} className={activeSection === key ? "block" : "hidden"}>
+            {component}
+          </div>
+        ))}
       </section>
     </div>
   );

--- a/app/guard-view/page.jsx
+++ b/app/guard-view/page.jsx
@@ -120,6 +120,8 @@ export default function GuardView() {
       await visitRequestByGuard(requestData);
       toast.success("Visit request raised successfully.");
       setRequest({ name: "", purpose: "", department: "", clientId: "", vehicleImage: "" });
+      fetchLogs();
+      fetchScheduled();
     } catch (err) {
       toast.error("Failed to raise visit request.");
     } finally {
@@ -263,7 +265,11 @@ export default function GuardView() {
                       <DialogTitle>Capture License Plate</DialogTitle>
                     </DialogHeader>
                     <div className="mt-4 flex flex-col items-center space-y-4">
-                      <Webcam ref={webcamRef} screenshotFormat="image/jpeg" />
+                      <Webcam
+                        ref={webcamRef}
+                        screenshotFormat="image/jpeg"
+                        videoConstraints={{ facingMode: { exact: "environment" } }}
+                      />
                       <Button onClick={handlePlateCapture} className="mt-2">Capture</Button>
                     </div>
                   </DialogContent>
@@ -339,7 +345,11 @@ export default function GuardView() {
                           <DialogTitle>Capture License Plate</DialogTitle>
                         </DialogHeader>
                         <div className="mt-4 flex flex-col items-center space-y-4">
-                          <Webcam ref={webcamRef} screenshotFormat="image/jpeg" />
+                          <Webcam
+                            ref={webcamRef}
+                            screenshotFormat="image/jpeg"
+                            videoConstraints={{ facingMode: { exact: "environment" } }}
+                          />
                           <Button onClick={handleCheckPlateCapture} className="mt-2">Capture</Button>
                         </div>
                       </DialogContent>


### PR DESCRIPTION
## Summary
- default rear-facing camera for license plate capture
- refresh guard lists after submitting a visit request
- raise TIMEOUT alerts for overstayed visitors
- keep client and end user dashboard data when switching tabs
- show red dot on dashboard tabs when new requests, alerts, or records arrive

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6877814450a0832fa166d0eba296604b